### PR TITLE
[#5] 모임 생성페이지 - 캘린더 추가 & 스크롤바 없앰

### DIFF
--- a/app/components/Calendar/Calendar.tsx
+++ b/app/components/Calendar/Calendar.tsx
@@ -166,7 +166,7 @@ export default function Calendar({
 
   useEffect(() => {
     onDateSelect(selectDate);
-  }, [selectDate, onDateSelect]);
+  }, [selectDate]);
 
   const baseCalendar = () => {
     const firstDay = new Date(

--- a/app/moimCreate/page.tsx
+++ b/app/moimCreate/page.tsx
@@ -167,15 +167,15 @@ export default function MoimCreate() {
   };
 
   return (
-    <div className="flex flex-col items-center">
-      <section className="relative flex text-black font-suit w-full items-center justify-center text-[28px] font-semibold leading-none">
+    <div className="flex flex-col items-center h-full">
+      <header className="relative flex text-black font-suit w-full items-center justify-center text-[28px] font-semibold leading-none">
         <Link href={"/"} className="absolute top-0 left-0">
           <img src="/back.svg" alt="뒤로 가기" />
         </Link>
         <span>모임 생성하기</span>
-      </section>
+      </header>
 
-      <section className="flex flex-col p-6 justify-center  gap-10 self-stretch mt-6 mb-6 rounded-[2px] bg-[#F6F5F2]">
+      <main className="flex-1 overflow-y-auto flex flex-col p-6 gap-5 self-stretch mt-6 mb-6 rounded-[2px] bg-[#F6F5F2]">
         <section>
           <Title text="1. 모임명을 입력하세요." />
           <input
@@ -221,7 +221,13 @@ export default function MoimCreate() {
           <div className="text-gray-500 text-[10px] ">
             참여자는 해당 기간 내에서 가능한 날짜를 선택하게 됩니다.
           </div>
-          <Calendar startDate={startDate} endDate={endDate} limit={1} />
+          <Calendar
+            startDate={startDate}
+            endDate={endDate}
+            onDateSelect={() => {}}
+            size="S"
+            range={true}
+          />
           {/* <button>기간 설정하기(캘린더 모달)</button> */}
           <div className="text-[12px] text-red-500">{validData.date}</div>
           <div>시작날짜 ~ 끝날짜</div>
@@ -237,14 +243,15 @@ export default function MoimCreate() {
           />
           <div className="text-[12px] text-red-500">{validData.time}</div>
         </section>
-      </section>
-
-      <button
-        onClick={handleSubmit}
-        className="text-[#FFF] font-[SUIT Variable] text-[17px] font-bold flex w-full h-[53px] p-4 justify-center items-center self-stretch rounded-[8px] hover:bg-[#51B1E0] bg-[#3a8bb5]"
-      >
-        모임 생성하기
-      </button>
+      </main>
+      <footer className="flex w-full">
+        <button
+          onClick={handleSubmit}
+          className="text-[#FFF] font-[SUIT Variable] text-[17px] font-bold flex w-full h-[53px] p-4 justify-center items-center self-stretch rounded-[8px] hover:bg-[#51B1E0] bg-[#3a8bb5]"
+        >
+          모임 생성하기
+        </button>
+      </footer>
     </div>
   );
 }

--- a/app/moimCreate/page.tsx
+++ b/app/moimCreate/page.tsx
@@ -7,6 +7,7 @@ import { title } from "process";
 import { createMoimApi } from "../api/api";
 import { MoimDataType, MoimMemberType } from "../type/type";
 import { useRouter } from "next/navigation";
+import Calendar from "../components/Calendar/Calendar";
 
 export default function MoimCreate() {
   const router = useRouter();
@@ -30,6 +31,10 @@ export default function MoimCreate() {
     date: "",
     time: "",
   });
+
+  const startDate = new Date();
+  const endDate = new Date(startDate);
+  endDate.setMonth(startDate.getMonth() + 3);
 
   const onCreateMoim = async (data: MoimDataType) => {
     try {
@@ -216,7 +221,8 @@ export default function MoimCreate() {
           <div className="text-gray-500 text-[10px] ">
             참여자는 해당 기간 내에서 가능한 날짜를 선택하게 됩니다.
           </div>
-          <button>기간 설정하기(캘린더 모달)</button>
+          <Calendar startDate={startDate} endDate={endDate} limit={1} />
+          {/* <button>기간 설정하기(캘린더 모달)</button> */}
           <div className="text-[12px] text-red-500">{validData.date}</div>
           <div>시작날짜 ~ 끝날짜</div>
         </section>

--- a/app/moimCreate/page.tsx
+++ b/app/moimCreate/page.tsx
@@ -9,19 +9,14 @@ import { MoimDataType, MoimMemberType } from "../type/type";
 import { useRouter } from "next/navigation";
 import Calendar from "../components/Calendar/Calendar";
 
-interface RangeDate {
-  startDate: Date | null;
-  endDate: Date | null;
-}
-
 export default function MoimCreate() {
   const router = useRouter();
   const [moimData, setMoimData] = useState<MoimDataType>({
     title: "",
     status: "",
     members: [],
-    startDate: new Date(),
-    endDate: new Date(20241226),
+    startDate: null,
+    endDate: null,
     time: "",
     pickDate: [],
     top3: [],
@@ -29,10 +24,6 @@ export default function MoimCreate() {
 
   const [membersArray, setMembersArray] = useState<string[]>([]);
   const [memberName, setMemberName] = useState<string>("");
-  const [rangeDate, setRangeDate] = useState<RangeDate>({
-    startDate: null,
-    endDate: null,
-  });
 
   const [validData, setValidData] = useState({
     title: "",
@@ -70,22 +61,21 @@ export default function MoimCreate() {
     const secondDay = dates[1];
     console.log("선택한 날짜", dates);
     if (dates.length <= 1) {
-      setRangeDate({
+      setMoimData({
+        ...moimData,
         startDate: firstDay,
         endDate: null,
       });
     }
     if (dates.length >= 2) {
-      setRangeDate((prev: RangeDate): RangeDate => {
+      setMoimData((prev: MoimDataType): MoimDataType => {
         if (firstDay < secondDay) {
-          return { startDate: firstDay, endDate: secondDay };
+          return { ...prev, startDate: firstDay, endDate: secondDay };
         } else {
-          return { startDate: secondDay, endDate: firstDay };
+          return { ...prev, startDate: secondDay, endDate: firstDay };
         }
       });
     }
-
-    console.log("현재 범위 데이터", rangeDate);
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -261,13 +251,13 @@ export default function MoimCreate() {
             range={true}
           />
           <div className="text-[12px] text-red-500">{validData.date}</div>
-          <div>
-            {rangeDate.startDate
-              ? rangeDate.startDate.toLocaleDateString()
+          <div className="text-center">
+            {moimData.startDate
+              ? moimData.startDate.toLocaleDateString()
               : "시작 날짜"}{" "}
             ~{" "}
-            {rangeDate.endDate
-              ? rangeDate.endDate.toLocaleDateString()
+            {moimData.endDate
+              ? moimData.endDate.toLocaleDateString()
               : "종료 날짜"}
           </div>
         </section>

--- a/app/moimCreate/page.tsx
+++ b/app/moimCreate/page.tsx
@@ -9,6 +9,11 @@ import { MoimDataType, MoimMemberType } from "../type/type";
 import { useRouter } from "next/navigation";
 import Calendar from "../components/Calendar/Calendar";
 
+interface RangeDate {
+  startDate: Date | null;
+  endDate: Date | null;
+}
+
 export default function MoimCreate() {
   const router = useRouter();
   const [moimData, setMoimData] = useState<MoimDataType>({
@@ -24,6 +29,10 @@ export default function MoimCreate() {
 
   const [membersArray, setMembersArray] = useState<string[]>([]);
   const [memberName, setMemberName] = useState<string>("");
+  const [rangeDate, setRangeDate] = useState<RangeDate>({
+    startDate: null,
+    endDate: null,
+  });
 
   const [validData, setValidData] = useState({
     title: "",
@@ -54,6 +63,29 @@ export default function MoimCreate() {
       [name]: value,
     });
     console.log("현재 모임 데이터", moimData);
+  };
+
+  const handleDateSelect = (dates: Date[]) => {
+    const firstDay = dates[0];
+    const secondDay = dates[1];
+    console.log("선택한 날짜", dates);
+    if (dates.length <= 1) {
+      setRangeDate({
+        startDate: firstDay,
+        endDate: null,
+      });
+    }
+    if (dates.length >= 2) {
+      setRangeDate((prev: RangeDate): RangeDate => {
+        if (firstDay < secondDay) {
+          return { startDate: firstDay, endDate: secondDay };
+        } else {
+          return { startDate: secondDay, endDate: firstDay };
+        }
+      });
+    }
+
+    console.log("현재 범위 데이터", rangeDate);
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -224,13 +256,20 @@ export default function MoimCreate() {
           <Calendar
             startDate={startDate}
             endDate={endDate}
-            onDateSelect={() => {}}
+            onDateSelect={handleDateSelect}
             size="S"
             range={true}
           />
-          {/* <button>기간 설정하기(캘린더 모달)</button> */}
           <div className="text-[12px] text-red-500">{validData.date}</div>
-          <div>시작날짜 ~ 끝날짜</div>
+          <div>
+            {rangeDate.startDate
+              ? rangeDate.startDate.toLocaleDateString()
+              : "시작 날짜"}{" "}
+            ~{" "}
+            {rangeDate.endDate
+              ? rangeDate.endDate.toLocaleDateString()
+              : "종료 날짜"}
+          </div>
         </section>
 
         <section>

--- a/app/moimCreate/page.tsx
+++ b/app/moimCreate/page.tsx
@@ -197,7 +197,7 @@ export default function MoimCreate() {
         <span>모임 생성하기</span>
       </header>
 
-      <main className="flex-1 overflow-y-auto flex flex-col p-6 gap-5 self-stretch mt-6 mb-6 rounded-[2px] bg-[#F6F5F2]">
+      <main className="flex-1 overflow-y-auto flex flex-col p-6 gap-5 self-stretch mt-6 mb-6 rounded-[2px] bg-[#F6F5F2] scrollbar-gutter-stable no-scrollbar">
         <section>
           <Title text="1. 모임명을 입력하세요." />
           <input

--- a/app/moimSelectdate/page.tsx
+++ b/app/moimSelectdate/page.tsx
@@ -12,6 +12,9 @@ import { MoimMemberType } from "../type/type";
 // 내용 꽉 찬 예시시
 // 6777f0c59fe275be55856418
 
+// 날짜 생성
+//677df17429403c63c51d695b
+
 export default function MoimSelectDate() {
   const [moimData, setMoimData] = useState({
     _id: "",

--- a/app/type/type.ts
+++ b/app/type/type.ts
@@ -2,8 +2,8 @@ export interface MoimDataType {
   title: string;
   status: string;
   members: MoimMemberType[];
-  startDate: Date;
-  endDate: Date;
+  startDate: Date | null;
+  endDate: Date | null;
   time: string;
   pickDate: Date[];
   top3: Date[];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,5 +14,15 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    function ({ addComponents }) {
+      addComponents({
+        ".no-scrollbar": {
+          "-webkit-scrollbar": "none",
+          "-ms-overflow-style": "none" /* IE 10+ */,
+          "scrollbar-width": "none" /* Firefox */,
+        },
+      });
+    },
+  ],
 } satisfies Config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import { PluginAPI } from "tailwindcss/types/config";
 
 export default {
   content: [
@@ -15,7 +16,7 @@ export default {
     },
   },
   plugins: [
-    function ({ addComponents }) {
+    function ({ addComponents }: PluginAPI) {
       addComponents({
         ".no-scrollbar": {
           "-webkit-scrollbar": "none",


### PR DESCRIPTION
📖 작업 내용
모임 생성 페이지에 캘린더 추가
시작 날짜, 종료 날짜 선택 가능
스크롤바 없앰
header, main, footer로 나누고 footer 는 하단 고정

✅ PR 포인트

📸 스크린샷 (option)
![image](https://github.com/user-attachments/assets/c24e3d3a-1126-4ed2-964e-b9b2314a83c7)
